### PR TITLE
Suppress the new {% svelte %} tag when seen

### DIFF
--- a/engines/jekyll-engine/src/index.js
+++ b/engines/jekyll-engine/src/index.js
@@ -9,6 +9,7 @@ const engine = new Liquid({
 engine.plugin(require('./plugins/bem-mods.js'));
 engine.plugin(require('./plugins/jsonify.js'));
 engine.plugin(require('./plugins/slugify-plugin.js'));
+engine.plugin(require('./plugins/svelte.js'));
 
 const jekyllEngine = {
   render: (component, props, options) => {

--- a/engines/jekyll-engine/src/plugins/svelte.js
+++ b/engines/jekyll-engine/src/plugins/svelte.js
@@ -1,0 +1,22 @@
+/**
+ * Inside the plugin function, `this` refers to the Liquid instance.
+ *
+ * @param Liquid: provides facilities to implement tags and filters.
+ */
+module.exports = function (Liquid) {
+    this.registerTag('svelte', {
+	  parse: function(token){
+	  	this.svelteName = token.args.split(' ')[0];
+	  },
+	  render: function(ctx, hash) {
+		return `<!-- START Supressing Svelte tag for ${this.svelteName} -->`;
+	  }
+	});
+    this.registerTag('endsvelte', {
+	  parse: function(token){
+	  },
+	  render: function(ctx, hash) {
+		return `<!-- END supressing Svelte tag -->`;
+	  }
+	});
+}


### PR DESCRIPTION
Starting to integrate the svelte tags, but we don't want the behaviour reflected in bookshop since framework is selectable.