### PR TITLE
Promote bookshop-gen as the gen command to prevent conflicts

### DIFF
--- a/examples/example-bookshop/package.json
+++ b/examples/example-bookshop/package.json
@@ -13,7 +13,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "start-storybook -p 4999",
     "build": "build-storybook -c .storybook -o ../../dist",
-    "gen": "gen"
+    "gen": "bookshop-gen"
   },
   "author": "@LiamBigelow",
   "license": "MIT",

--- a/gen/package.json
+++ b/gen/package.json
@@ -14,6 +14,7 @@
   "author": "@LiamBigelow",
   "license": "MIT",
   "bin": {
+    "bookshop-gen": "src/index.js",
     "gen": "src/index.js"
   },
   "publishConfig": {


### PR DESCRIPTION
Still push gen as the user's command in the storybook folder for fewer keystrokes