### PR TITLE
Renaming TOML field to structures

### DIFF
--- a/generator-plugins/jekyll/cloudcannon-jekyll-bookshop/lib/cloudcannon-jekyll-bookshop/structures.rb
+++ b/generator-plugins/jekyll/cloudcannon-jekyll-bookshop/lib/cloudcannon-jekyll-bookshop/structures.rb
@@ -44,7 +44,7 @@ module CloudCannonJekyllBookshop
     end
 
     def self.add_structure(hash, component)
-      array_structures = component.delete("array_structures")
+      array_structures = component.delete("structures")
       array_structures.each do |key|
         hash[key] ||= {}
         hash[key]["values"] ||= []

--- a/generator-plugins/jekyll/cloudcannon-jekyll-bookshop/spec/fixture_bookshop/components/item/item.bookshop.toml
+++ b/generator-plugins/jekyll/cloudcannon-jekyll-bookshop/spec/fixture_bookshop/components/item/item.bookshop.toml
@@ -1,5 +1,5 @@
 [component]
-array_structures = [ "item_array_structure" ]
+structures = [ "item_array_structure" ]
 label = "Item Label"
 description = "Item Description"
 icon = "flare"

--- a/generator-plugins/jekyll/cloudcannon-jekyll-bookshop/spec/helpers/test_helpers.rb
+++ b/generator-plugins/jekyll/cloudcannon-jekyll-bookshop/spec/helpers/test_helpers.rb
@@ -68,7 +68,7 @@ module CloudCannonJekyllBookshop
     def self.base_bookshop_config
       <<~TOML
         [component]
-        array_structures = [ "content_blocks" ]
+        structures = [ "content_blocks" ]
         label = "Testing Component"
         description = "Description of testing component"
         icon = "nature_people"
@@ -78,7 +78,7 @@ module CloudCannonJekyllBookshop
 
     def self.base_bookshop_output
       {
-        "array_structures" => %w(content_blocks bookshop_components),
+        "structures" => %w(content_blocks bookshop_components),
         "label"            => "Testing Component",
         "description"      => "Description of testing component",
         "icon"             => "nature_people",

--- a/generator-plugins/jekyll/jekyll-bookshop/README.md
+++ b/generator-plugins/jekyll/jekyll-bookshop/README.md
@@ -34,12 +34,12 @@ To use components directly in a template, use the `{% bookshop %}` tag like you 
 >...
 >```
 
-To use components as an editor in CloudCannon, define a front matter key that matches a key specified in a component's `array_structures` metadata. For example:
+To use components as an editor in CloudCannon, define a front matter key that matches a key specified in a component's `structures` metadata. For example:
 
 >#### `hero.bookshop.toml`
 >```toml
 >[component]
->array_structures = [ "content_blocks" ]
+>structures = [ "content_blocks" ]
 >```
 
 >#### `index.html`

--- a/guides/conventions.adoc
+++ b/guides/conventions.adoc
@@ -91,7 +91,7 @@ The component TOML file for our button might look like the following:
 .*button.bookshop.toml*
 ```toml
 [component]
-array_structures = [ "editor_components" ]
+structures = [ "editor_components" ]
 label = "Button"
 description = "Outbound CTA links"
 icon = "smart_button"
@@ -107,7 +107,7 @@ open_in_new_tab = false
 
 The `[component]` block defines this component, and is used to configure page building interfaces. The fields are the following:
 
-array_structures:: Used to configure editing interfaces
+structures:: Used to configure editing interfaces
 label:: Editor-friendly name
 description:: Editor-friendly description
 icon:: Material icon name

--- a/javascript-modules/browser/lib/app/svelte/lib/helpers-hydrate.test.js
+++ b/javascript-modules/browser/lib/app/svelte/lib/helpers-hydrate.test.js
@@ -11,7 +11,7 @@ const stubbedEngines = [{
 
 const tomlExample = `
 [component]
-array_structures = []
+structures = []
 label = "Stub"
 description = ""
 icon = "crop_7_5"
@@ -40,7 +40,7 @@ test("should hydrate basic components", t => {
     t.is(hydrated["stub-component-a"].yaml, `label: Stub\ntype: A\n`);
 
     t.deepEqual(hydrated["stub-component-a"].identity, {
-        array_structures: [],
+        structures: [],
         label: "Stub",
         description: "",
         icon: "crop_7_5",

--- a/javascript-modules/browser/lib/app/svelte/lib/info-pane.svelte
+++ b/javascript-modules/browser/lib/app/svelte/lib/info-pane.svelte
@@ -48,9 +48,9 @@
                 {/each}
                 </p>
 
-                {#if component?.identity?.array_structures}
+                {#if component?.identity?.structures}
                 <p class="title">Structures</p>
-                <p class="label">{component.identity.array_structures.join(', ')}</p>
+                <p class="label">{component.identity.structures.join(', ')}</p>
                 {/if}
 
                 {#if component?.identity?.tags}

--- a/javascript-modules/cloudcannon-structures/main.js
+++ b/javascript-modules/cloudcannon-structures/main.js
@@ -29,14 +29,14 @@ const TransformComponent = (path, component) => {
             _bookshop_name: GetComponentKey(path)
         },
         label: NiceLabel(GetComponentKey(path)), // Used as a fallback when no label is supplied inside [component]
-        array_structures: [],
+        structures: [],
         ...component["component"]
     }
     if (component["props"]) {
         TransformComponentProps(component["props"], result, null);
     }
-    if (!result["_hidden"] && !result["array_structures"].includes("bookshop_components")) {
-        result["array_structures"].push("bookshop_components");
+    if (!result["_hidden"] && !result["structures"].includes("bookshop_components")) {
+        result["structures"].push("bookshop_components");
     }
     
     const results = [result];

--- a/javascript-modules/cloudcannon-structures/main.test.js
+++ b/javascript-modules/cloudcannon-structures/main.test.js
@@ -15,7 +15,7 @@ test("should get component key", t => {
 test("should merge component definitions", t => {
   const bookshop_component = helpers.loadTestTOML(helpers.f`
   [component]
-  array_structures = [ "content_blocks" ]
+  structures = [ "content_blocks" ]
   label = "Unique Component"
   description = "Unique Component Description"
   icon = "nature_people"
@@ -24,7 +24,7 @@ test("should merge component definitions", t => {
   const bookshop_structure = Testables.TransformComponent(helpers.base_bookshop_path, bookshop_component)
   
   t.deepEqual(bookshop_structure, [{
-    "array_structures": [ "content_blocks", "bookshop_components" ],
+    "structures": [ "content_blocks", "bookshop_components" ],
     "label": "Unique Component",
     "description": "Unique Component Description",
     "icon": "nature_people",
@@ -43,7 +43,7 @@ test("should hide hidden components", t => {
   const bookshop_structure = Testables.TransformComponent(helpers.base_bookshop_path, bookshop_component)
   
   t.deepEqual(bookshop_structure, [{
-    "array_structures": [],
+    "structures": [],
     "label": "Component Subcomponent",
     "value": {
       "_bookshop_name": "component/subcomponent",

--- a/javascript-modules/cloudcannon-structures/util/_test-helpers.js
+++ b/javascript-modules/cloudcannon-structures/util/_test-helpers.js
@@ -11,14 +11,14 @@ module.exports = {
     base_bookshop_path: "component/subcomponent/subcomponent.bookshop.tomml",
     base_bookshop_config: f`
     [component]
-    array_structures = [ "content_blocks" ]
+    structures = [ "content_blocks" ]
     label = "Testing Component"
     description = "Description of testing component"
     icon = "nature_people"
     tags = [ "one", "two", "three" ]
     `,
     base_bookshop_output: {
-        "array_structures": [ "content_blocks", "bookshop_components" ],
+        "structures": [ "content_blocks", "bookshop_components" ],
         "label": "Testing Component",
         "description": "Description of testing component",
         "icon": "nature_people",

--- a/javascript-modules/generator-plugins/eleventy/cloudcannon-eleventy-bookshop/main.js
+++ b/javascript-modules/generator-plugins/eleventy/cloudcannon-eleventy-bookshop/main.js
@@ -39,8 +39,8 @@ window.addEventListener('load', function() {
 }
 
 const addComponentTo = (obj, component) => {
-    const {array_structures, ...fields} = component;
-    array_structures?.forEach(structure => {
+    const {structures, ...fields} = component;
+    structures?.forEach(structure => {
         obj[structure] = obj[structure] || {};
         obj[structure]["values"] = obj[structure]["values"] || [];
         obj[structure]["values"].push(fields);

--- a/javascript-modules/integration-tests/features/eleventy/eleventy_bookshop_structures.feature
+++ b/javascript-modules/integration-tests/features/eleventy/eleventy_bookshop_structures.feature
@@ -35,7 +35,7 @@ Feature: Eleventy Bookshop CloudCannon Integration
     Given a component-lib/components/card/card.bookshop.toml file containing:
       """
       [component]
-      array_structures = [ "content_blocks" ]
+      structures = [ "content_blocks" ]
       label = "Card"
       description = "Card component"
       icon = "nature_people"

--- a/javascript-modules/integration-tests/features/jekyll/jekyll_bookshop_structures.feature
+++ b/javascript-modules/integration-tests/features/jekyll/jekyll_bookshop_structures.feature
@@ -19,7 +19,7 @@ Feature: Jekyll Bookshop CloudCannon Integration
     Given a component-lib/components/card/card.bookshop.toml file containing:
       """
       [component]
-      array_structures = [ "content_blocks" ]
+      structures = [ "content_blocks" ]
       label = "Card"
       description = "Card component"
       icon = "nature_people"


### PR DESCRIPTION
Changes the TOML spec from `array_structures` to `structures` to be less reliant on CloudCannon terminology