### PR TITLE
Update live rendering bookshop nested name parsing

### DIFF
--- a/javascript-modules/live/lib/app/app.js
+++ b/javascript-modules/live/lib/app/app.js
@@ -78,7 +78,7 @@ window.BookshopLive = class BookshopLive {
 
                 stack.push({
                     startNode: currentNode,
-                    name: matches.groups["name"].split('/').pop().split('.').shift(),
+                    name: matches.groups["name"].replace(/\/\w+\..+$/, ''),
                     bindings: JSON.parse(JSON.stringify(bindings)),
                     scope
                 });


### PR DESCRIPTION
The new live rendering incorrectly parses a nested component like `utility/button` as `button`, which won't render correctly.