### PR TITLE
feat: automatically set the array structure id_key for components

### DIFF
--- a/generator-plugins/jekyll/cloudcannon-jekyll-bookshop/lib/cloudcannon-jekyll-bookshop/structures.rb
+++ b/generator-plugins/jekyll/cloudcannon-jekyll-bookshop/lib/cloudcannon-jekyll-bookshop/structures.rb
@@ -47,6 +47,7 @@ module CloudCannonJekyllBookshop
       array_structures = component.delete("structures")
       array_structures.each do |key|
         hash[key] ||= {}
+        hash[key]["id_key"] = "_bookshop_name"
         hash[key]["values"] ||= []
         hash[key]["values"].push(component)
       end

--- a/generator-plugins/jekyll/cloudcannon-jekyll-bookshop/spec/test_structures/output_spec.rb
+++ b/generator-plugins/jekyll/cloudcannon-jekyll-bookshop/spec/test_structures/output_spec.rb
@@ -12,6 +12,7 @@ module CloudCannonJekyllBookshop
       output_data = JSON.parse TestHelpers.read_output_file("_cloudcannon/info.json")
 
       info_diff = Hashdiff.diff(output_data.dig("_array_structures", "item_array_structure"), {
+        "id_key" => "_bookshop_name",
         "values" => [
           {
             "value"             => {

--- a/javascript-modules/generator-plugins/eleventy/cloudcannon-eleventy-bookshop/main.js
+++ b/javascript-modules/generator-plugins/eleventy/cloudcannon-eleventy-bookshop/main.js
@@ -42,6 +42,7 @@ const addComponentTo = (obj, component) => {
     const {structures, ...fields} = component;
     structures?.forEach(structure => {
         obj[structure] = obj[structure] || {};
+        obj[structure]["id_key"] = "_bookshop_name"
         obj[structure]["values"] = obj[structure]["values"] || [];
         obj[structure]["values"].push(fields);
     });

--- a/javascript-modules/integration-tests/features/eleventy/eleventy_bookshop_structures.feature
+++ b/javascript-modules/integration-tests/features/eleventy/eleventy_bookshop_structures.feature
@@ -51,6 +51,7 @@ Feature: Eleventy Bookshop CloudCannon Integration
     And stdout should not be empty
     And site/_site/_cloudcannon/info.json should leniently contain each row: 
       | text |
+      | "id_key" : "_bookshop_name" |
       | "value" : { "_bookshop_name" : "card" , "card_text" : null, "color" : "Blue" } |
       | "label" : "Card"                                                               |
       | "_select_data" : { "colors" : [ "Red" , "Blue" ] }                             |

--- a/javascript-modules/integration-tests/features/jekyll/jekyll_bookshop_structures.feature
+++ b/javascript-modules/integration-tests/features/jekyll/jekyll_bookshop_structures.feature
@@ -34,6 +34,7 @@ Feature: Jekyll Bookshop CloudCannon Integration
     Then stderr should be empty
     And site/_site/_cloudcannon/info.json should leniently contain each row: 
       | text |
+      | "id_key" : "_bookshop_name" |
       | "value" : { "_bookshop_name" : "card" , "card_text" : null, "color" : "Blue" } |
       | "label" : "Card"                                                               |
       | "_select_data" : { "colors" : [ "Red" , "Blue" ] }                             |


### PR DESCRIPTION
Insert `_id_key` into CloudCannon array structures,
so that structures are matched against the `_bookshop_name` field
instead of a deep object comparison.
This makes the front matter across a website more resilient
if component schemas change.