### PR TITLE
Update jekyll.adoc

### DIFF
--- a/guides/eleventy.adoc
+++ b/guides/eleventy.adoc
@@ -167,7 +167,7 @@ Reference `npx @bookshop/sass --help` to see the available options.
 
 == Component Library
 
-Setting up the component library is fairly framework agnostic, so following the steps in the link:guides/browser.adoc[Component Browser Guide] should see you on your way.
+Setting up the component library is fairly framework agnostic, so following the steps in the link:browser.adoc[Component Browser Guide] should see you on your way.
 
 == Live Editing
 
@@ -197,4 +197,4 @@ module.exports = function (eleventyConfig) {
 };
 ```
 
-With that dependency installed, follow the instructions in the link:guides/live-editing.adoc[Live Editing Guide]
+With that dependency installed, follow the instructions in the link:live-editing.adoc[Live Editing Guide]

--- a/guides/jekyll.adoc
+++ b/guides/jekyll.adoc
@@ -150,7 +150,7 @@ This bundles all Bookshop SCSS files into the Jekyll Sass pipeline.
 
 == Component Library
 
-Setting up the component library is fairly framework agnostic, so following the steps in the link:guides/browser.adoc[Component Browser Guide] should see you on your way.
+Setting up the component library is fairly framework agnostic, so following the steps in the link:browser.adoc[Component Browser Guide] should see you on your way.
 
 == Live Editing
 
@@ -176,5 +176,5 @@ bookshop_locations:
   - ../component-library
 ```
 
-With that dependency installed, follow the instructions in the link:guides/live-editing.adoc[Live Editing Guide]
+With that dependency installed, follow the instructions in the link:live-editing.adoc[Live Editing Guide]
 

--- a/guides/live-editing.adoc
+++ b/guides/live-editing.adoc
@@ -63,8 +63,8 @@ TIP: You can supply the `-b` flag multiple times if you want to merge Bookshops.
 The Bookshop generator frameworks provide helpers for integrating live editing with your website.
 
 Within Jekyll, the *cloudcannon-jekyll-bookshop* plugin provides a `bookshop_live` tag to embed the browser on a given page. Within Eleventy, this tag is supplied by the *@bookshop/cloudcannon-eleventy-bookshop* plugin. +
-See the link:guides/jekyll.adoc[Jekyll] 
-or link:guides/eleventy.adoc[Eleventy] 
+See the link:jekyll.adoc[Jekyll] 
+or link:eleventy.adoc[Eleventy] 
 guides for instructions on installing these plugins.
 
 The syntax is the same across both generators:


### PR DESCRIPTION
Links currently point to https://github.com/CloudCannon/bookshop/blob/main/guides**/guides/**browser.adoc  rather than https://github.com/CloudCannon/bookshop/blob/main/guides/browser.adoc 