### PR TITLE
fix(live): patch for complex layouts assigning html to variables

### DIFF
--- a/javascript-modules/live/lib/app/core.js
+++ b/javascript-modules/live/lib/app/core.js
@@ -24,6 +24,8 @@ const parseComment = node => {
  * and note down the sum absolute path of the new name if we can
  */
 export const storeResolvedPath = (name, identifier, pathStack) => {
+    // TODO: This shouldn't be required post-tokenizer 
+    if (!name || !identifier) return;
     // TODO: The `include.` replacement feels too SSG coupled.
     //                       v v v v v v v v v v v v 
     identifier = identifier.replace(/^include\./, '').replace(/\[(\d+)]/g, '.$1').split('.');
@@ -105,6 +107,8 @@ const evaluateTemplate = async (liveInstance, documentNode, parentPathStack, tem
         const { matches, contextMatches } = parseComment(currentNode);
 
         for (const [name, identifier] of parseParams(contextMatches?.groups["context"])) {
+            // TODO: This shouldn't be required post-tokenizer 
+            if (!identifier) return;
             // TODO: bindings here has no encapsulation / stack, which feels too SSG-coupled for assigns
             // TODO: bindings here has no encapsulation / stack, which is wrong for loops
             bindings[name] = await liveInstance.eval(identifier, combinedScope());
@@ -120,6 +124,8 @@ const evaluateTemplate = async (liveInstance, documentNode, parentPathStack, tem
             const params = parseParams(matches.groups["params"]);
             pathStack.push({});
             for (const [name, identifier] of params) {
+                // TODO: This shouldn't be required post-tokenizer 
+                if (!identifier) return;
                 if (name === 'bind') {
                     const bindVals = await liveInstance.eval(identifier, combinedScope());
                     if (bindVals && typeof bindVals === 'object') {


### PR DESCRIPTION
Some complex sites are hitting a live editing error in complex layouts. This should fix those sites to re-render from the root if an error is hit on a nested template.