### PR TITLE
feat: attempt to load the hugo wasm from a cdn where possible

### DIFF
--- a/javascript-modules/engines/hugo-engine/hugo-renderer/build.sh
+++ b/javascript-modules/engines/hugo-engine/hugo-renderer/build.sh
@@ -1,16 +1,57 @@
-rm -f hugo_renderer.wasm
-FILENAME="hugo_renderer_$(date +%s).wasm"
-GOOS=js GOARCH=wasm go build -tags nodeploy -o $FILENAME
-printf "Built Hugo WASM via $FILENAME : "
-ls -lh $FILENAME | awk '{print $5}'
-if [ -f hugo_renderer.wasm ]; then
-    echo "ERROR: previous hugo_renderer.wasm still in directory"
+if [[ -z "${BOOKSHOP_VERSION}" ]]; then
+    echo "ERROR: BOOKSHOP_VERSION environment variable does not exist"
     exit 1
 fi
-mv $FILENAME hugo_renderer.wasm
-if [ ! -f hugo_renderer.wasm ]; then
+
+TMPFILENAME="hugo_renderer_$(date +%s).wasm"
+OUTPUTFILENAME="hugo_renderer.wasm"
+CDNFILENAME="../../../../../bookshopcdn/hugo/hugo_renderer_$BOOKSHOP_VERSION.wasm"
+
+# Clean
+rm -f $OUTPUTFILENAME
+if [ -f $OUTPUTFILENAME ]; then
+    echo "ERROR: previous $OUTPUTFILENAME still in directory"
+    exit 1
+fi
+
+# Build temp module
+GOOS=js GOARCH=wasm go build -tags nodeploy -o $TMPFILENAME
+printf "Built Hugo WASM via $TMPFILENAME : "
+ls -lh $TMPFILENAME | awk '{print $5}'
+
+# Link repo module
+mv $TMPFILENAME $OUTPUTFILENAME
+if [ ! -f $OUTPUTFILENAME ]; then
     echo "ERROR: hugo_renderer.wasm not complete"
     exit 1
 fi
-echo "Done. Hugo WASM available at hugo_renderer.wasm"
+echo "Done. Repo Hugo WASM available at hugo_renderer.wasm"
+
+# If we're just in a test run we don't want to touch the CDN repo
+if [[ -z "${PUBLISH_BOOKSHOP_CDN}" ]]; then
+    echo "Not publishing to CDN."
+    exit 0
+fi
+
+# Check CDN
+if [ ! -d ../../../../../bookshopcdn/hugo ]; then
+    echo "ERROR: bookshopcdn repo does not exist alongside bookshop repo"
+    exit 1
+fi
+
+# Link CDN module
+cp $OUTPUTFILENAME $CDNFILENAME
+if [ ! -f $CDNFILENAME ]; then
+    echo "ERROR: $CDNFILENAME not complete"
+    exit 1
+fi
+echo "Done. CDN Hugo WASM available at $CDNFILENAME"
+
+cd ../../../../../bookshopcdn
+
+git add -A \
+&& git commit -m "build: releasing $BOOKSHOP_VERSION" \
+&& git tag -a v$BOOKSHOP_VERSION -m "build: releasing $BOOKSHOP_VERSION" \
+&& git push --tags && git push
+
 exit 0

--- a/javascript-modules/integration-tests/support/steps.js
+++ b/javascript-modules/integration-tests/support/steps.js
@@ -189,7 +189,7 @@ const loadPage = async (url, world) => {
 const readyCloudCannon = async (data, world) => {
   if (!world.page) throw Error("No page open");
   const script = `window.CC = class CloudCannon {
-    constructor(options) { this.data = options.data; document.dispatchEvent(this.event('cloudcannon:load')); }
+    constructor(options) { this.isMocked = true; this.data = options.data; document.dispatchEvent(this.event('cloudcannon:load')); }
     newData(data) { this.data = data; document.dispatchEvent(this.event('cloudcannon:update')); }
     event(name) { return new CustomEvent(name, { detail: { CloudCannon: this } });}
     enableEvents() {}
@@ -337,4 +337,4 @@ Given(/^🌐 I (?:have loaded|load) my site in CloudCannon$/i, { timeout: 60 * 1
   }
 
   assert.deepEqual(this.puppeteerErrors(), []);
-}); //yaml.load(input)
+});


### PR DESCRIPTION
Loads `hugo_renderer.wasm` from `cdn.bookshop.build` for faster initialization by hitting the Cloudflare cache there. 

Falls back to the wasm file hosted alongside the active javascript if for any reason the CDN request fails.