### PR TITLE
Fixed component lookup for shared/svelte/page.svelte

### DIFF
--- a/javascript-modules/generator-plugins/sveltekit/sveltekit-bookshop/Bookshop.svelte
+++ b/javascript-modules/generator-plugins/sveltekit/sveltekit-bookshop/Bookshop.svelte
@@ -30,7 +30,7 @@
     } else if (shared) {
         path = `shared/svelte/${shared}.svelte`;
     } else if ($$restProps._bookshop_name) {
-        path = `components/${$$restProps._bookshop_name}/${$$restProps._bookshop_name}.svelte`;
+        path = getComponentKey($$restProps._bookshop_name);
     } else {
         throw new Error("No component or shared key passed to Bookshop.");
     }


### PR DESCRIPTION
Say you have a component with the following file structure:
```
[component-folder]
└── nested
    └── component
        ├── component.svelte
        └── component.bookshop.yaml
```

And the following object in your SvelteKit route:
```
component: {
  "_bookshop_name": "nested/component"
  "component_key": "component_value"
}
```

You _should_ be able to render this using `<Bookshop {...component} />`.

However, Bookshop trips up due to the fact that the component is within a folder (`nested/`). Bookshop will look for the file `[component-folder]/component/nested/component/nested.svelte`, which does not exist.

The fix is to use the existing `getComponentKey()` function.