### PR TITLE
Fix nested object arrays within a component blueprint

### DIFF
--- a/javascript-modules/generate/lib/structure-builder.js
+++ b/javascript-modules/generate/lib/structure-builder.js
@@ -101,11 +101,17 @@ const generateDeepStructures = ({ blueprint, currentBlueprintKey, inputs, cascad
             inputs[currentBlueprintKey] = inputs[currentBlueprintKey] || {};
             inputs[currentBlueprintKey].options = inputs[currentBlueprintKey].options || {};
 
+            const deepInputs = {};
             const structure = {
                 label: niceLabel(pluralize.singular(currentBlueprintKey)),
                 icon: "add_box",
-                value: generateDeepStructures({ blueprint: blueprint[0], currentBlueprintKey, inputs, cascadeFields }),
+                value: generateDeepStructures({ blueprint: blueprint[0], currentBlueprintKey, inputs: deepInputs, cascadeFields }),
                 ...cascadeFields,
+            };
+            structure._inputs = structure._inputs || {};
+            structure._inputs = {
+                ...structure._inputs,
+                ...deepInputs
             };
 
             inputs[currentBlueprintKey].type = "array";

--- a/javascript-modules/integration-tests/features/generate/structure_generation.feature
+++ b/javascript-modules/integration-tests/features/generate/structure_generation.feature
@@ -186,6 +186,52 @@ Feature: Bookshop Structure Generation
       | _structures.blocks.values.0._inputs.my_links.options.structures.values.0._inputs.text.comment | "Text comment" |
       | _structures.blocks.values.0._inputs.my_links.options.structures.values.0._misc.something_else | true           |
 
+  Scenario: Nested object arrays become nested structures
+    Given a component-lib/components/card/card.bookshop.yml file containing:
+      """
+      spec:
+        structures:
+          - blocks
+
+      blueprint:
+        title: Hello World
+        nested:
+          - title: "Nested Object #1"
+            double_nested:
+              - title: "Nested Object #2"
+                triple_nested:
+                  - title: "Nested Object #3"
+      """
+    When I run "npm start" in the . directory
+    Then stderr should be empty
+    And stdout should contain "Added 1 structure from 1 Bookshop to 1 site."
+    # Base structure
+    Then I should see "site/public/_cloudcannon/info.json" containing the values:
+      | path                                             | value         |
+      | _structures.blocks.values.0.value._bookshop_name | "card"        |
+      | _structures.blocks.values.0.value.title          | "Hello World" |
+      | _structures.blocks.values.0.value.nested         | []            |
+    # First nested structure
+    Then I should see "site/public/_cloudcannon/info.json" containing the values:
+      | path                                                                                       | value              |
+      | _structures.blocks.values.0._inputs.nested.type                                            | "array"            |
+      | _structures.blocks.values.0._inputs.nested.options.structures.values.0.label               | "Nested"           |
+      | _structures.blocks.values.0._inputs.nested.options.structures.values.0.value.title         | "Nested Object #1" |
+      | _structures.blocks.values.0._inputs.nested.options.structures.values.0.value.double_nested | []                 |
+    # Second nested structure
+    Then I should see "site/public/_cloudcannon/info.json" containing the values:
+      | path                                                                                                                                         | value              |
+      | _structures.blocks.values.0._inputs.nested.options.structures.values.0._inputs.double_nested.type                                            | "array"            |
+      | _structures.blocks.values.0._inputs.nested.options.structures.values.0._inputs.double_nested.options.structures.values.0.label               | "Double Nested"    |
+      | _structures.blocks.values.0._inputs.nested.options.structures.values.0._inputs.double_nested.options.structures.values.0.value.title         | "Nested Object #2" |
+      | _structures.blocks.values.0._inputs.nested.options.structures.values.0._inputs.double_nested.options.structures.values.0.value.triple_nested | []                 |
+    # Third nested structure
+    Then I should see "site/public/_cloudcannon/info.json" containing the values:
+      | path                                                                                                                                                                                   | value              |
+      | _structures.blocks.values.0._inputs.nested.options.structures.values.0._inputs.double_nested.options.structures.values.0._inputs.triple_nested.type                                    | "array"            |
+      | _structures.blocks.values.0._inputs.nested.options.structures.values.0._inputs.double_nested.options.structures.values.0._inputs.triple_nested.options.structures.values.0.label       | "Triple Nested"    |
+      | _structures.blocks.values.0._inputs.nested.options.structures.values.0._inputs.double_nested.options.structures.values.0._inputs.triple_nested.options.structures.values.0.value.title | "Nested Object #3" |
+
   Scenario: JSON config is supported
     Given a component-lib/components/a/b/c/d/e/e.bookshop.json file containing:
       """


### PR DESCRIPTION
```yaml
blueprint:
  title: Hello World
  nested:
    - title: "Nested Object #1"
      double_nested:
        - title: "Nested Object #2" # <-- This one would not work.
```