### PR TITLE
Skip template commenting in Eleventy and Jekyll when no subcomponents

### DIFF
--- a/javascript-modules/engines/eleventy-engine/lib/translateLiquid.js
+++ b/javascript-modules/engines/eleventy-engine/lib/translateLiquid.js
@@ -83,6 +83,14 @@ export default function (text, opts) {
         ...opts
     }
     text = text.toString();
+
+    // If this component contains no subcomponents,
+    // we don't need to add any special comments as there
+    // can be no data bindings within.
+    if (!/bookshop/.test(text)) {
+        opts.liveMarkup = false;
+    }
+
     const tokenizer = new Tokenizer(text);
     const output = tokenizer.readTopLevelTokens();
 

--- a/javascript-modules/engines/eleventy-engine/lib/translateLiquid.test.js
+++ b/javascript-modules/engines/eleventy-engine/lib/translateLiquid.test.js
@@ -62,25 +62,31 @@ test("add live markup to bookshop_include tags", t => {
 });
 
 test("add live markup to assigns", t => {
-    const input = `{% assign a=b %}`;
-    const expected = `{% assign a=b %}<!--bookshop-live context(a: (b))-->`;
+    const input = `{% assign a=b %}bookshop`;
+    const expected = `{% assign a=b %}<!--bookshop-live context(a: (b))-->bookshop`;
     t.is(translateLiquid(input, { expandBindSyntax: false }), expected);
 });
 
 test("add live markup to complex assigns", t => {
-    const input = `{% assign a = b | where: "a", "b" %}`;
-    const expected = `{% assign a = b | where: "a", "b" %}<!--bookshop-live context(a: (b | where: "a", "b"))-->`;
+    const input = `{% assign a = b | where: "a", "b" %}bookshop`;
+    const expected = `{% assign a = b | where: "a", "b" %}<!--bookshop-live context(a: (b | where: "a", "b"))-->bookshop`;
     t.is(translateLiquid(input, { expandBindSyntax: false }), expected);
 });
 
 test("add live markup to local assigns", t => {
-    const input = `{% local a=b %}`;
-    const expected = `{% local a=b %}<!--bookshop-live context(a: (b))-->`;
+    const input = `{% local a=b %}bookshop`;
+    const expected = `{% local a=b %}<!--bookshop-live context(a: (b))-->bookshop`;
     t.is(translateLiquid(input, { expandBindSyntax: false }), expected);
 });
 
 test("add live markup to loops", t => {
-    const input = `{% for a in b %}`;
-    const expected = `{% for a in b %}{% loop_context a in b %}`;
+    const input = `{% for a in b %}bookshop`;
+    const expected = `{% for a in b %}{% loop_context a in b %}bookshop`;
+    t.is(translateLiquid(input, { expandBindSyntax: false }), expected);
+});
+
+test("don't add live markup when no subcomponent", t => {
+    const input = `{% assign a=b %}`;
+    const expected = `{% assign a=b %}`;
     t.is(translateLiquid(input, { expandBindSyntax: false }), expected);
 });

--- a/javascript-modules/engines/hugo-engine/lib/translateTextTemplate.js
+++ b/javascript-modules/engines/hugo-engine/lib/translateTextTemplate.js
@@ -124,6 +124,10 @@ export default function (text, opts) {
         liveMarkup: true,
         ...opts
     }
+
+    // If this component contains no subcomponents,
+    // we don't need to add any special comments as there
+    // can be no data bindings within.
     if (!/bookshop/.test(text)) {
         return text;
     }

--- a/javascript-modules/engines/jekyll-engine/lib/translateLiquid.js
+++ b/javascript-modules/engines/jekyll-engine/lib/translateLiquid.js
@@ -77,6 +77,14 @@ export default function (text, opts) {
         ...opts
     }
     text = text.toString();
+
+    // If this component contains no subcomponents,
+    // we don't need to add any special comments as there
+    // can be no data bindings within.
+    if (!/bookshop/.test(text)) {
+        opts.liveMarkup = false;
+    }
+
     const tokenizer = new Tokenizer(text);
     const output = tokenizer.readTopLevelTokens();
 

--- a/javascript-modules/engines/jekyll-engine/lib/translateLiquid.test.js
+++ b/javascript-modules/engines/jekyll-engine/lib/translateLiquid.test.js
@@ -68,25 +68,31 @@ test("add live markup to bookshop_include tags", t => {
 });
 
 test("add live markup to assigns", t => {
-    const input = `{% assign a=b %}`;
-    const expected = `{% assign a=b %}<!--bookshop-live context(a: (b))-->`;
+    const input = `{% assign a=b %}bookshop`;
+    const expected = `{% assign a=b %}<!--bookshop-live context(a: (b))-->bookshop`;
     t.is(translateLiquid(input, { expandBindSyntax: false }), expected);
 });
 
 test("add live markup to complex assigns", t => {
-    const input = `{% assign a = b | where: "a", "b" %}`;
-    const expected = `{% assign a = b | where: "a", "b" %}<!--bookshop-live context(a: (b | where: "a", "b"))-->`;
+    const input = `{% assign a = b | where: "a", "b" %}bookshop`;
+    const expected = `{% assign a = b | where: "a", "b" %}<!--bookshop-live context(a: (b | where: "a", "b"))-->bookshop`;
     t.is(translateLiquid(input, { expandBindSyntax: false }), expected);
 });
 
 test("add live markup to local assigns", t => {
-    const input = `{% local a=b %}`;
-    const expected = `{% local a=b %}<!--bookshop-live context(a: (b))-->`;
+    const input = `{% local a=b %}bookshop`;
+    const expected = `{% local a=b %}<!--bookshop-live context(a: (b))-->bookshop`;
     t.is(translateLiquid(input, { expandBindSyntax: false }), expected);
 });
 
 test("add live markup to loops", t => {
-    const input = `{% for a in b %}`;
-    const expected = `{% for a in b %}{% loop_context a in b %}`;
+    const input = `{% for a in b %}bookshop`;
+    const expected = `{% for a in b %}{% loop_context a in b %}bookshop`;
+    t.is(translateLiquid(input, { expandBindSyntax: false }), expected);
+});
+
+test("don't add live markup when no subcomponent", t => {
+    const input = `{% assign a=b %}`;
+    const expected = `{% assign a=b %}`;
     t.is(translateLiquid(input, { expandBindSyntax: false }), expected);
 });


### PR DESCRIPTION
Reduces the workload of Bookshop when analyzing data bindings, as components with no children don't need processing. This optimization already exists for Hugo, this PR adds it for Eleventy and Jekyll.