### PR TITLE
Describe Hugo minify configuration requirements

### DIFF
--- a/guides/hugo.adoc
+++ b/guides/hugo.adoc
@@ -1672,6 +1672,8 @@ If you're using other components in your layouts, add the `bookshop_bindings` pa
 {{ partial "bookshop_bindings" `(dict hero_text .Params.hero_text)` }}
 {{ partial "bookshop" (slice "hero" (dict hero_text .Params.hero_text)) }}
 ----
+
+WARNING: Hugo has a built-in option to minify output files, which is enabled by adding the `--minify` flag to the `hugo` command. Be sure to keep the HTML comments though (`keepComments = true`), or else Bookshop will not be able to generate the correct page bindings. Refer to the link:https://gohugo.io/getting-started/configuration/#configure-minify[Hugo documentation] for more information.
 endif::hugo[]
 
 ifndef::sveltekit[]


### PR DESCRIPTION
When building my Hugo site with CloudCannon, I noticed `npx @bookshop/generate` could not find any pages that referenced a (custom) Bookshop component. My site did have a few test pages that referenced such a component. After some debugging, I noticed the following line was scanning the built HTML files for an HTML comment:

https://github.com/CloudCannon/bookshop/blob/6010d46d810d786d5c089980130759e4637546e6/javascript-modules/generate/lib/live-connector.js#L67

As it turns out, the `--minify` flag (which I had enabled in the CloudCannon build configuration / command line options) was purging all HTML comments from the output files. Adjusting the Hugo minify configuration fixed the issue and enabled the visual editing of the Bookshop component. I added the following configuration to `hugo.toml`:

```toml
[minify]
  [minify.tdewolff.html]
      keepComments = true
```

I prepared a small revision to the Hugo docs to help others who might encounter similar issues. To keep it concise, I linked to the Hugo docs only. Feel free to share your comments about this PR.