### PR TITLE
fix(astro-engine): Add support for GIF, TIFF and AVIF image imports

### DIFF
--- a/javascript-modules/engines/astro-engine/lib/builder.js
+++ b/javascript-modules/engines/astro-engine/lib/builder.js
@@ -177,7 +177,7 @@ export const buildPlugins = [
           loader: "js",
         };
       });
-      build.onResolve({ filter: /^\/.*\.(svg|png|jpe?g|webp)/ }, (args) => {
+      build.onResolve({ filter: /^\/.*\.(svg|png|jpe?g|webp|gif|tiff|avif)/ }, (args) => {
         return { path: join(process.cwd(), "public", args.path) };
       });
       build.onLoad({ filter: /\.(j|t)sx$/ }, async (args) => {
@@ -266,6 +266,9 @@ export const buildPlugins = [
           args.path.endsWith(".jpg") ||
           args.path.endsWith(".jpeg") ||
           args.path.endsWith(".webp") ||
+          args.path.endsWith(".gif") ||
+          args.path.endsWith(".tiff") ||
+          args.path.endsWith(".avif") ||
           args.path.endsWith(".json") ||
           args.path.endsWith(".ts")
         ) {
@@ -321,6 +324,9 @@ export const esbuildConfigFn = (esbuildOptions, options) => {
     ".jpg": "file",
     ".jpeg": "file",
     ".webp": "file",
+    ".gif": "file",
+    ".tiff": "file",
+    ".avif": "file",
     ".ts": "ts",
     ...esbuildOptions.loader,
   };


### PR DESCRIPTION
I'm using astro:image to optimise image assets, which appeared to be working with bookshop until I added a company logo in GIF format.

`error: No loader is configured for ".gif" files: src/assets/pages/community/page.md/logo.gif`

astro:image uses [sharp](https://sharp.pixelplumbing.com/) by default to optimise images, which supports JPEG, PNG, WebP, GIF, AVIF, TIFF and SVG images. Currently bookshop build fails if GIF, TIFF or AVIF images are imported.

I have not tested this patch beyond importing a gif, tiff and avif image and building the site, which appears to work. 
The tiff image does not render in the editor as tiff is not a supported image format in firefox, however the optimised version of the image on the live site is webp and renders correctly.