### PR TITLE
fix(astro-engine): ensure clientDirectives is defined

### DIFF
--- a/javascript-modules/engines/astro-engine/lib/engine.js
+++ b/javascript-modules/engines/astro-engine/lib/engine.js
@@ -151,7 +151,12 @@ export class Engine {
         hasRenderedHead: true,
         hasDirectives: new Set(),
       },
-      clientDirectives: new Map(),
+      clientDirectives: new Map([
+	["load", "bookshop-placeholder"],
+	["idle", "bookshop-placeholder"],
+	["visible", "bookshop-placeholder"],
+	["media", "bookshop-placeholder"],
+      ]),
       slots: null,
       props,
       createAstro(astroGlobal, props, slots) {

--- a/javascript-modules/engines/astro-engine/lib/engine.js
+++ b/javascript-modules/engines/astro-engine/lib/engine.js
@@ -151,6 +151,7 @@ export class Engine {
         hasRenderedHead: true,
         hasDirectives: new Set(),
       },
+      clientDirectives: new Map(),
       slots: null,
       props,
       createAstro(astroGlobal, props, slots) {


### PR DESCRIPTION
https://github.com/withastro/astro/pull/13858 (Merged in Astro 5.8.1) breaks bookshop live as `validateComponentProps` now expects `SSRResult.clientDirectives` to be defined, preventing rendering and causing the following warning in the editor:

```
Error rendering bookshop component Page TypeError: can't access property "keys", clientDirectives is undefined
This is expected in certain cases, and may not be an issue, especially when deleting or re-ordering components.
```