### PR TITLE
Bugfix for nested wrappers in React

### DIFF
--- a/javascript-modules/generator-plugins/astro/vite-plugin-astro-bookshop/processors/react-jsx.js
+++ b/javascript-modules/generator-plugins/astro/vite-plugin-astro-bookshop/processors/react-jsx.js
@@ -464,6 +464,8 @@ export default (src, componentName, includeErrorBoundaries) => {
 
     Object.keys(node).forEach((key) => delete node[key]);
     Object.keys(template).forEach((key) => (node[key] = template[key]));
+    // You have to reparse the tree to ensure that the parent links are updated
+    addParentLinks(tree);
   });
 
   if (includeErrorBoundaries) {


### PR DESCRIPTION
An issue occurred with the generated code where if you had two wrappers using `{children}` syntax next to eachother like so:
```js
<Wrapper>
  <WrapperTwo>
    Hello
  </WrapperTwo>
<Wrapper>
```
The generated code would add a function block inside of `<Wrapper>` like so:
```js
<Wrapper>
  (() => {})
<Wrapper>
```

Which wasn't being properly wrapped in `{}`. The reason for this is that as the tree changes the parent for the second node `<WrapperTwo>` wouldn't be the JSXElement `<Wrapper>` but instead a "CallExpression".

By reparsing the tree we fix the parent back to the JSXElement.