### PR TITLE
Update hugo.adoc

### DIFF
--- a/guides/hugo.adoc
+++ b/guides/hugo.adoc
@@ -1793,6 +1793,8 @@ endif::sveltekit[]
 
 NOTE: This flag only applies to the component directly and doesn't cascade down. Any subcomponents will follow the standard rules, or can also specify their own Data Binding flag.
 
+To disable all data bindings on your site, you can add the flag `--disable-bindings` to your `@bookshop/generate` command in your site's `postbuild`.
+
 ////
 //
 //

--- a/guides/hugo.adoc
+++ b/guides/hugo.adoc
@@ -1793,7 +1793,7 @@ endif::sveltekit[]
 
 NOTE: This flag only applies to the component directly and doesn't cascade down. Any subcomponents will follow the standard rules, or can also specify their own Data Binding flag.
 
-To disable all data bindings on your site, you can add the flag `--disable-bindings` to your `@bookshop/generate` command in your site's `postbuild`.
+To disable all data bindings on your site, you can add the flag `--disable-bindings` to your `@bookshop/generate` command in your site's `postbuild`. This can significantly improve rendering performance for complex sites.
 
 ////
 //


### PR DESCRIPTION
- Add note for how to disable all data bindings on your site via the `@bookshop/generate` command

Released [here](https://github.com/CloudCannon/bookshop/releases/tag/v3.12.0), but undocumented.