### PR TITLE
Fix wrong style import

### DIFF
--- a/guides/hugo.adoc
+++ b/guides/hugo.adoc
@@ -751,7 +751,7 @@ To include all of your Bookshop styles in Hugo, you can use the `bookshop_scss` 
 {{ $bookshop_scss_files := partial "bookshop_scss" . }}
 {{ $scss := $bookshop_scss_files | resources.Concat "css/bookshop.css" | resources.ToCSS | resources.Minify |
     resources.Fingerprint }}
-<link rel="stylesheet" href="{{ $scss.Permalink }}">
+<link rel="stylesheet" href="{{ $scss.RelPermalink }}">
 ```
 
 endif::hugo[]


### PR DESCRIPTION
**Issue with Stylesheet Path Resolution**

There is an issue with how styles are attached to the HTML document.

When the project runs locally, there are no issues - styles are attached with relative paths like:

`<link rel="stylesheet" href="/css/bookshop.min.8cdbddfdsgf.css">`

However, in CloudCannon, the customer domain is sometimes unexpectedly attached during the build process, even when no domain is configured at the project level. This causes issues when CloudCannon users rely on the generated domain.

This fix prevents the domain from being attached, which resolves the stylesheet loading problems.

You should investigate why the domain is being attached to stylesheet links when it's not configured at the project level.