### PR TITLE
Fix: add lowercase fallback for component names in Hugo 0.146

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ## Unreleased
 
+* Adds a lowercase fallback as Hugo 0.146 normalises template names to lowercase.
+
 ## v3.18.2 (March 25, 2026)
 
 * Resolve an issue preventing release to NPM.

--- a/hugo/v3/core/helpers/component.html
+++ b/hugo/v3/core/helpers/component.html
@@ -15,11 +15,17 @@
 {{- $component_path := partial "_bookshop/helpers/component_key" $component_name -}}
 {{- $flat_component_path := partial "_bookshop/helpers/flat_component_key" $component_name -}}
 
+{{- $component_path_lower := lower $component_path -}}
+{{- $flat_component_path_lower := lower $flat_component_path -}}
 {{- $resolved_component := false -}}
 {{- if templates.Exists ( printf "partials/%s" $component_path ) -}}
     {{- $resolved_component = $component_path -}}
+{{- else if templates.Exists ( printf "partials/%s" $component_path_lower ) -}}
+    {{- $resolved_component = $component_path_lower -}}
 {{- else if templates.Exists ( printf "partials/%s" $flat_component_path ) -}}
     {{- $resolved_component = $flat_component_path -}}
+{{- else if templates.Exists ( printf "partials/%s" $flat_component_path_lower ) -}}
+    {{- $resolved_component = $flat_component_path_lower -}}
 {{- end -}}
 
 {{- if $resolved_component -}}


### PR DESCRIPTION
Hugo 0.146 normalises template names to lowercase. 

- `common/paths/pathparser.go` → `parse()` → `NormalizePathStringBasic(s)` which calls `strings.ToLower(s)` on all template paths
- `tpl/tplimpl/templatestore.go` → `HasTemplate()` (in 0.146.0) does case-sensitive lookup against these lowercase-stored keys
- PR #13541 introduced this new `PathParser`-based template system in Hugo 0.146.0

However, bookshop looks for components as is - components with uppercase names (e.g. `CTA-simple`, `OS-badge`) fail the `templates.Exists` check because the stored filename is lowercase but the lookup is not.

Adds a lowercase fallback so both casings are tried before giving up.