### PR TITLE
Batch component renders in live connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ## Unreleased
 
+* Use batch component rendering for editable regions when the engine supports it.
 * Fixed component rendering race condition in Hugo Bookshop.
 
 ## v3.18.4 (June 18, 2026)

--- a/javascript-modules/generate/lib/live-connector.js
+++ b/javascript-modules/generate/lib/live-connector.js
@@ -95,6 +95,35 @@ const getEditableRegionsConnector = () => {
       script.onload = function() {
         window.bookshopLive = new window.BookshopLive({ remoteGlobals: [] });
 
+        let renderQueue = [];
+        let renderFlushTimer = null;
+
+        const flushRenderQueue = async () => {
+          renderFlushTimer = null;
+          if (renderQueue.length === 0) return;
+
+          const batch = renderQueue;
+          renderQueue = [];
+
+          const components = batch.map((entry) => ({
+            name: entry.key,
+            scope: entry.props,
+            dom: entry.rootEl,
+          }));
+
+          try {
+            await window.bookshopLive.renderElements(components);
+            for (const entry of batch) {
+              entry.resolve(entry.rootEl);
+            }
+          } catch (e) {
+            for (const entry of batch) {
+              entry.reject(e);
+            }
+          }
+        };
+
+        const engineSupportsBatching = window.bookshopLive.supportsBatchRendering();
         window.cc_components = window.cc_components || {};
         window.cc_components = new Proxy(window.cc_components, {
           get(target, key) {
@@ -112,20 +141,29 @@ const getEditableRegionsConnector = () => {
              * @param {any} props - Props to pass to the Bookshop Live component
              * @returns {Promise<HTMLElement>} The rendered component as an HTMLElement
              */
-            const wrappedComponent = async (props) => {
-              const rootEl = document.createElement("div");
-
+            const wrappedComponent = (props) => {
               if (!window.bookshopLive) {
                 throw new Error("Bookshop Live is not initialized");
               }
 
-              await window.bookshopLive.renderElement(
-                key,
-                props,
-                rootEl,
-              )
+              const rootEl = document.createElement("div");
 
-              return rootEl;
+              if (!engineSupportsBatching) {
+                await window.bookshopLive.renderElement(
+                  key,
+                  props,
+                  rootEl,
+                );
+                return rootEl;
+              }
+
+              return new Promise((resolve, reject) => {
+                renderQueue.push({ key, props, rootEl, resolve, reject });
+
+                if (renderFlushTimer === null) {
+                  renderFlushTimer = setTimeout(flushRenderQueue, 50);
+                }
+              });
             };
 
             return wrappedComponent;

--- a/javascript-modules/generate/lib/live-connector.js
+++ b/javascript-modules/generate/lib/live-connector.js
@@ -141,7 +141,7 @@ const getEditableRegionsConnector = () => {
              * @param {any} props - Props to pass to the Bookshop Live component
              * @returns {Promise<HTMLElement>} The rendered component as an HTMLElement
              */
-            const wrappedComponent = (props) => {
+            const wrappedComponent = async (props) => {
               if (!window.bookshopLive) {
                 throw new Error("Bookshop Live is not initialized");
               }

--- a/javascript-modules/live/lib/app/live.js
+++ b/javascript-modules/live/lib/app/live.js
@@ -107,6 +107,15 @@ export const getLive = (engines) => class BookshopLive {
     }
 
     /**
+     * Whether the active engine supports batch rendering via renderBatch.
+     * Used by the live editing connector to decide whether to debounce and
+     * collect component renders into a single renderElements call.
+     */
+    supportsBatchRendering() {
+        return typeof this.engines[0]?.renderBatch === 'function';
+    }
+
+    /**
      * Render multiple components in a single batch for better performance.
      * Falls back to individual renders if the engine doesn't support batching.
      * 


### PR DESCRIPTION
This PR adds logic to check if a Bookshop engine supports batch component rendering, and then to use that for the editable regions connector